### PR TITLE
fix: support express 5 compatibility

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,92 @@
+# Copilot Instructions
+
+## Build & Run Commands
+
+- `npm run dev` - Start dev server with nodemon (port 8000)
+- `npm run prod` - Start in production mode with nodemon
+- `npm start` - Start production server (no nodemon)
+- `npm run build:js` - Bundle frontend JS with esbuild, minified + sourcemap
+- `npm run watch:js` - Watch mode for frontend JS bundling
+- `npm test` is a placeholder that exits 1; no test framework is configured
+
+## Linting & Formatting
+
+- ESLint uses Airbnb + Prettier + Node plugin via flat config in
+  `eslint.config.mjs`
+- Prettier uses 80-char width, 4-space tabs, single quotes, semicolons, and
+  `arrowParens: "always"` in `.prettierrc`
+- No npm lint/format scripts are configured; run ESLint/Prettier directly if
+  needed
+
+## Architecture
+
+**Stack**: Node.js 20.x, Express 5.x, MongoDB/Mongoose 9.x, Pug SSR, Stripe,
+esbuild
+
+**Pattern**: MVC with factory-based CRUD handlers.
+
+```text
+server.js        -> Entry point: env loading, MongoDB connection, listen
+app.js           -> Express setup: middleware stack and route mounting
+controllers/     -> Business logic, including handlerFactory.js CRUD helpers
+models/          -> Mongoose schemas for Tour, User, Review, Booking
+routes/          -> Express routers; reviews/bookings can nest under tours
+utils/           -> AppError, catchAsync, APIFeatures, Email
+views/           -> Pug templates for pages, partials, and emails
+public/          -> Static CSS/images/frontend JS and esbuild output
+```
+
+## Key Patterns
+
+- Application code uses CommonJS (`require`, `module.exports`,
+  `exports.fnName`); `eslint.config.mjs` is the ESM exception.
+- Async route handlers should use `catchAsync` and pass operational errors with
+  `next(new AppError(message, statusCode))`.
+- Reuse `controllers/handlerFactory.js` for standard CRUD (`getAll`, `getOne`,
+  `createOne`, `updateOne`, `deleteOne`) before adding bespoke controller
+  logic.
+- API responses generally use `{ status: 'success', data: { doc } }`, with
+  `results` for list endpoints.
+- `utils/apiFeatures.js` provides chainable filtering, sorting, field limiting,
+  and pagination for list endpoints.
+- Auth stores JWTs in cookies and uses `protect` then `restrictTo(...)` for
+  protected/role-limited routes.
+
+## Coding Conventions
+
+- Files and functions use camelCase, e.g. `tourController.js`,
+  `getAllTours`, `createBookingCheckout`.
+- Controllers use named exports: `exports.fnName = catchAsync(async (...) => {})`.
+- Route mounting follows `/api/v1/tours`, `/api/v1/users`,
+  `/api/v1/reviews`, and `/api/v1/bookings`.
+- File upload/image processing uses Multer memory storage plus Sharp, following
+  the existing tour/user controller patterns.
+
+## Security Middleware Stack
+
+`app.js` configures Helmet CSP, CORS, rate limiting, static assets, body parsers
+with a 10kb limit, cookie parsing, NoSQL sanitization, XSS sanitization, HPP,
+compression, and development-only Morgan logging.
+
+## Environment
+
+Config is loaded from `config.env`; use `config.env.example` for the core shape.
+The code expects MongoDB, JWT, Mailtrap/Gmail OAuth, login lockout, and Stripe
+values. Keep secrets out of source control. The example omits some code-required
+values, including `MAILTRAP_FROM`, `STRIPE_SECRET_KEY`, and
+`STRIPE_WEBHOOK_SECRET`.
+
+## Gotchas
+
+- Keep `/webhook-checkout` in `app.js` before `express.json()` so Stripe can
+  verify the raw request body.
+- Express 5 makes `req.query` read-only; sanitizers in `app.js` intentionally
+  sanitize body/headers rather than assigning to `req.query`.
+- `config.env` is local secret material; do not read, print, or commit it.
+
+## CI/CD
+
+- Dependabot checks npm dependencies weekly via `.github/dependabot.yml`.
+- `.github/workflows/dependabot-automerge.yml` auto-approves and squash-merges
+  Dependabot patch/minor updates.
+- Deployment is documented as Render.com in `README.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ coverage/
 bower_components/
 
 # Editor directories and files
+.DS_Store
 .idea/
 .vscode/
 dev-data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,11 @@
 
 - ESLint: Airbnb + Prettier + Node plugin (flat config in `eslint.config.mjs`)
 - Prettier: 80-char width, 4-space tabs, single quotes, semicolons required (`.prettierrc`)
+- No npm lint/format scripts are configured; run ESLint/Prettier directly if needed
 
 ## Architecture
 
-**Stack**: Node.js 20.x, Express, MongoDB/Mongoose, Pug (SSR), Stripe, esbuild
+**Stack**: Node.js 20.x, Express 5.x, MongoDB/Mongoose 9.x, Pug (SSR), Stripe, esbuild
 
 **Pattern**: MVC with factory-based CRUD handlers
 
@@ -56,10 +57,20 @@ cookie parser, mongo sanitize, XSS clean, HPP, compression
 
 ## Environment
 
-Config via `config.env` (see `config.env.example`): MongoDB URI, JWT secret/expiry,
-email (Mailtrap dev / OAuth prod), Stripe keys, login lockout settings
+Config via `config.env` (see `config.env.example` for core values): MongoDB URI,
+JWT secret/expiry, email (Mailtrap dev / OAuth prod), and login lockout settings.
+Code also expects `MAILTRAP_FROM`, `STRIPE_SECRET_KEY`, and
+`STRIPE_WEBHOOK_SECRET`; keep these in local/hosting env only.
+
+## Gotchas
+
+- Keep `/webhook-checkout` in `app.js` before `express.json()` so Stripe can
+  verify the raw request body.
+- Express 5 makes `req.query` read-only; sanitizers in `app.js` intentionally
+  sanitize body/headers rather than assigning to `req.query`.
 
 ## CI/CD
 
-- Dependabot only (`.github/dependabot.yml`), no GitHub Actions workflows
+- Dependabot (`.github/dependabot.yml`) + auto-merge workflow (`.github/workflows/dependabot-automerge.yml`)
+  - Auto-approves and squash-merges patch/minor dependency updates
 - Deployed on Render.com

--- a/app.js
+++ b/app.js
@@ -2,11 +2,11 @@ const hpp = require('hpp');
 const path = require('path');
 const morgan = require('morgan');
 const helmet = require('helmet');
-const xss = require('xss-clean');
 const express = require('express');
 const cookieParser = require('cookie-parser');
 const rateLimit = require('express-rate-limit');
-const mongoSanitize = require('express-mongo-sanitize');
+const { sanitize } = require('express-mongo-sanitize');
+const { clean } = require('xss-clean/lib/xss');
 const compression = require('compression');
 const cors = require('cors');
 
@@ -50,7 +50,7 @@ app.use(cors());
 //   origin: 'https://www.natours.com'
 // }))
 
-app.options('*', cors());
+app.options('/{*splat}', cors());
 // app.options('/api/v1/tours/:id', cors());
 
 // Serving static files from the 'public' directory (public folder)
@@ -109,10 +109,27 @@ app.use(express.urlencoded({ extended: true, limit: '10kb' }));
 app.use(cookieParser());
 
 // Data Sanitization against NoSQL query injection
-app.use(mongoSanitize());
+// Custom wrapper — express-mongo-sanitize's default middleware assigns to
+// req.query which is read-only in Express 5.
+app.use((req, res, next) => {
+	if (req.body) {
+		req.body = sanitize(req.body);
+	}
+	if (req.headers) {
+		req.headers = sanitize(req.headers);
+	}
+	next();
+});
 
 // Data Sanitization against XSS (Cross-Site Scripting)
-app.use(xss());
+// xss-clean has the same req.query issue; only sanitize req.body.
+// Pug auto-escapes output, so query/params are safe at render time.
+app.use((req, res, next) => {
+	if (req.body) {
+		req.body = clean(req.body);
+	}
+	next();
+});
 
 //prevent parameter pollution
 app.use(
@@ -143,7 +160,7 @@ app.use('/api/v1/reviews', reviewRouter);
 app.use('/api/v1/bookings', bookingRouter);
 
 // All other unimplemented routes return 404
-app.all('*', (req, res, next) => {
+app.all('/{*splat}', (req, res, next) => {
 	next(new AppError(`Cannot find ${req.originalUrl} on this server.`, 404));
 });
 

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -60,7 +60,7 @@ exports.signup = catchAsync(async (req, res, next) => {
 			status: 'success',
 			message: 'Verification email sent successfully. Check your inbox.',
 		});
-	} catch (error) {
+	} catch {
 		return next(
 			new AppError(
 				'There was an error sending email verification. Try again later.',
@@ -213,32 +213,45 @@ exports.protect = catchAsync(async (req, res, next) => {
 });
 
 // Only for rendered pages, no errors!
-exports.isLoggedIn = catchAsync(async (req, res, next) => {
+exports.isLoggedIn = async (req, res, next) => {
 	if (req.cookies?.jwt) {
-		// 1) Verify token
-		const decoded = await promisify(jwt.verify)(
-			req.cookies.jwt,
-			process.env.JWT_SECRET,
-		);
+		try {
+			// 1) Verify token
+			const decoded = await promisify(jwt.verify)(
+				req.cookies.jwt,
+				process.env.JWT_SECRET,
+			);
 
-		const { id } = decoded;
+			const { id } = decoded;
 
-		// 2) Check if user exists and is not deleted
-		const currUser = await User.findById(id);
-		if (!currUser) {
-			return next();
+			// 2) Check if user exists and is not deleted
+			const currUser = await User.findById(id);
+			if (!currUser) {
+				return next();
+			}
+
+			// 3) Check if user has changed password after token was issued
+			if (currUser.changedPasswordAfter(decoded.iat)) {
+				return next();
+			}
+
+			// THERE IS A LOGGED IN USER
+			res.locals.user = currUser;
+		} catch (err) {
+			if (
+				[
+					'JsonWebTokenError',
+					'TokenExpiredError',
+					'NotBeforeError',
+				].includes(err.name)
+			) {
+				return next();
+			}
+			return next(err);
 		}
-
-		// 3) Check if user has changed password after token was issued
-		if (currUser.changedPasswordAfter(decoded.iat)) {
-			return next();
-		}
-
-		// THERE IS A LOGGED IN USER
-		res.locals.user = currUser;
 	}
 	next();
-});
+};
 
 exports.restrictTo = (...roles) => {
 	return (req, res, next) => {
@@ -276,7 +289,7 @@ exports.forgotPassword = catchAsync(async (req, res, next) => {
 			status: 'success',
 			message: 'Reset password email sent',
 		});
-	} catch (err) {
+	} catch {
 		user.passwordResetToken = undefined;
 		user.passwordResetExpires = undefined;
 		await user.save({ validateBeforeSave: false });

--- a/models/bookingModel.js
+++ b/models/bookingModel.js
@@ -26,12 +26,11 @@ const bookingSchema = new mongoose.Schema({
 });
 
 // Populate the user and tour fields before executing find queries.
-bookingSchema.pre(/^find/, function (next) {
+bookingSchema.pre(/^find/, function () {
 	this.populate('user').populate({
 		path: 'tour',
 		select: 'name',
 	});
-	next();
 });
 
 const Booking = mongoose.model('Booking', bookingSchema);

--- a/models/reviewModel.js
+++ b/models/reviewModel.js
@@ -38,13 +38,11 @@ const reviewSchema = mongoose.Schema(
 reviewSchema.index({ tour: 1, user: 1 }, { unique: true });
 
 // Populate tour and user in the review response
-reviewSchema.pre(/^find/, async function (next) {
+reviewSchema.pre(/^find/, async function () {
 	this.populate({
 		path: 'user',
 		select: 'name photo',
 	});
-
-	next();
 });
 
 reviewSchema.statics.calcAverageRatings = async function (tourId) {
@@ -71,9 +69,8 @@ reviewSchema.post('save', function () {
 	this.constructor.calcAverageRatings(this.tour);
 });
 
-reviewSchema.pre(/^findOneAnd/, async function (next) {
+reviewSchema.pre(/^findOneAnd/, async function () {
 	this.r = await this.clone().findOne();
-	next();
 });
 
 reviewSchema.post(/^findOneAnd/, async function () {

--- a/models/tourModel.js
+++ b/models/tourModel.js
@@ -161,27 +161,24 @@ tourSchema.virtual('durationWeeks').get(function () {
 // 1) Document Middleware
 
 // runs before save and create commands, but not insert Many
-tourSchema.pre('save', function (next) {
+tourSchema.pre('save', function () {
 	this.slug = slugify(this.name, { lower: true });
-	next();
 });
 
 // 2) Query Middleware
 
 // Calculate Query execution time
-tourSchema.pre(/^find/, function (next) {
+tourSchema.pre(/^find/, function () {
 	this.find({ secretTour: { $ne: true } });
 	this.start = Date.now();
-	next();
 });
 
 // Populate guides in the response
-tourSchema.pre(/^find/, function (next) {
+tourSchema.pre(/^find/, function () {
 	this.populate({
 		path: 'guides',
 		select: '-__v -passwordChangedAt -loginAttempts -lockUntil',
 	});
-	next();
 });
 
 // Log query execution time

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -66,30 +66,26 @@ const userSchema = mongoose.Schema({
 userSchema.pre(
 	'save',
 	// run this function if password is modified
-	async function (next) {
+	async function () {
 		if (!this.isModified('password')) {
-			return next();
+			return;
 		}
 		this.password = await bcrypt.hash(this.password, 12);
 		this.passwordConfirm = undefined;
-		next();
 	},
 );
 
-userSchema.pre('save', function (next) {
+userSchema.pre('save', function () {
 	// Update changedPasswordAt if password is changed
 	if (!this.isModified('password') || this.isNew) {
-		return next();
+		return;
 	}
 	this.passwordChangedAt = Date.now() - 1000;
-
-	next();
 });
 
-userSchema.pre(/^find/, function (next) {
+userSchema.pre(/^find/, function () {
 	// (this) points to the current query
 	this.find({ active: { $ne: false } });
-	next();
 });
 
 // Instance method to compare password

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			"dependencies": {
 				"@babel/polyfill": "^7.12.1",
 				"@eslint/eslintrc": "^3.3.5",
-				"@eslint/js": "^9.39.4",
 				"bcryptjs": "^3.0.3",
 				"compression": "^1.7.4",
 				"cookie-parser": "^1.4.6",
@@ -38,8 +37,11 @@
 				"xss-clean": "^0.1.4"
 			},
 			"devDependencies": {
+				"@eslint/compat": "^1.4.1",
+				"@eslint/js": "^8.57.1",
 				"axios": "^1.16.0",
-				"eslint": "^9.39.4",
+				"eslint": "^8.57.1",
+				"eslint-config-airbnb": "^19.0.4",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-import": "^2.32.0",
 				"eslint-plugin-jsx-a11y": "^6.9.0",
@@ -579,25 +581,10 @@
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
-		"node_modules/@eslint/config-array": {
-			"version": "0.21.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@eslint/object-schema": "^2.1.7",
-				"debug": "^4.3.1",
-				"minimatch": "^3.1.5"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/@eslint/config-helpers": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+		"node_modules/@eslint/compat": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz",
+			"integrity": "sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -605,6 +592,14 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"peerDependencies": {
+				"eslint": "^8.40 || 9"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@eslint/core": {
@@ -656,63 +651,29 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://eslint.org/donate"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"node_modules/@eslint/object-schema": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/@eslint/plugin-kit": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+		"node_modules/@humanwhocodes/config-array": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+			"deprecated": "Use @eslint/config-array instead",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.17.0",
-				"levn": "^0.4.1"
+				"@humanwhocodes/object-schema": "^2.0.3",
+				"debug": "^4.3.1",
+				"minimatch": "^3.0.5"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/@humanfs/core": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18.18.0"
-			}
-		},
-		"node_modules/@humanfs/node": {
-			"version": "0.16.7",
-			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@humanfs/core": "^0.19.1",
-				"@humanwhocodes/retry": "^0.4.0"
-			},
-			"engines": {
-				"node": ">=18.18.0"
+				"node": ">=10.10.0"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -729,19 +690,13 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@humanwhocodes/retry": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+		"node_modules/@humanwhocodes/object-schema": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18.18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/nzakas"
-			}
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@img/colour": {
 			"version": "1.0.0",
@@ -1217,6 +1172,44 @@
 				"sparse-bitfield": "^3.0.3"
 			}
 		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/@pkgr/core": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -1253,13 +1246,6 @@
 				"selderee": "~0.12.0"
 			}
 		},
-		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1288,6 +1274,13 @@
 			"dependencies": {
 				"@types/webidl-conversions": "*"
 			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/accepts": {
 			"version": "2.0.0",
@@ -1346,6 +1339,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/ansi-styles": {
@@ -2010,6 +2013,13 @@
 				"typedarray": "^0.0.6"
 			}
 		},
+		"node_modules/confusing-browser-globals": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+			"integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/constantinople": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
@@ -2646,63 +2656,102 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.8.0",
-				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.2",
-				"@eslint/config-helpers": "^0.4.2",
-				"@eslint/core": "^0.17.0",
-				"@eslint/eslintrc": "^3.3.5",
-				"@eslint/js": "9.39.4",
-				"@eslint/plugin-kit": "^0.4.1",
-				"@humanfs/node": "^0.16.6",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.57.1",
+				"@humanwhocodes/config-array": "^0.13.0",
 				"@humanwhocodes/module-importer": "^1.0.1",
-				"@humanwhocodes/retry": "^0.4.2",
-				"@types/estree": "^1.0.6",
-				"ajv": "^6.14.0",
+				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
-				"cross-spawn": "^7.0.6",
+				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
+				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^8.4.0",
-				"eslint-visitor-keys": "^4.2.1",
-				"espree": "^10.4.0",
-				"esquery": "^1.5.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
-				"file-entry-cache": "^8.0.0",
+				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
+				"globals": "^13.19.0",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
+				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.5",
+				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3"
+				"optionator": "^0.9.3",
+				"strip-ansi": "^6.0.1",
+				"text-table": "^0.2.0"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://eslint.org/donate"
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-config-airbnb": {
+			"version": "19.0.4",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
+			"integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-config-airbnb-base": "^15.0.0",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.5"
+			},
+			"engines": {
+				"node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"peerDependencies": {
-				"jiti": "*"
+				"eslint": "^7.32.0 || ^8.2.0",
+				"eslint-plugin-import": "^2.25.3",
+				"eslint-plugin-jsx-a11y": "^6.5.1",
+				"eslint-plugin-react": "^7.28.0",
+				"eslint-plugin-react-hooks": "^4.3.0"
+			}
+		},
+		"node_modules/eslint-config-airbnb-base": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+			"integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"confusing-browser-globals": "^1.0.10",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.5",
+				"semver": "^6.3.0"
 			},
-			"peerDependenciesMeta": {
-				"jiti": {
-					"optional": true
-				}
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^7.32.0 || ^8.2.0",
+				"eslint-plugin-import": "^2.25.2"
 			}
 		},
 		"node_modules/eslint-config-prettier": {
@@ -2950,6 +2999,20 @@
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
 			}
 		},
+		"node_modules/eslint-plugin-react-hooks": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+			"integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+			}
+		},
 		"node_modules/eslint-plugin-react/node_modules/resolve": {
 			"version": "2.0.0-next.5",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -2969,9 +3032,9 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -2979,7 +3042,7 @@
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -3021,6 +3084,90 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/@eslint/eslintrc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^6.12.4",
+				"debug": "^4.3.2",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"minimatch": "^3.1.2",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/espree": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/espree": {
@@ -3219,17 +3366,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fastq": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
+		},
 		"node_modules/file-entry-cache": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^4.0.0"
+				"flat-cache": "^3.0.4"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
 		"node_modules/fill-range": {
@@ -3284,17 +3441,18 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"flatted": "^3.2.9",
-				"keyv": "^4.5.4"
+				"keyv": "^4.5.3",
+				"rimraf": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
 		"node_modules/flatted": {
@@ -3398,6 +3556,13 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -3519,6 +3684,28 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3573,6 +3760,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/has-bigints": {
 			"version": "1.1.0",
@@ -3856,6 +4050,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"node_modules/inherits": {
@@ -4176,6 +4382,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-promise": {
@@ -5345,6 +5561,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -5641,6 +5867,27 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -5791,6 +6038,34 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/reusify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/router": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -5812,6 +6087,30 @@
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
 			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"license": "MIT"
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
 		},
 		"node_modules/safe-array-concat": {
 			"version": "1.1.3",
@@ -6370,6 +6669,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -6449,6 +6761,13 @@
 			"funding": {
 				"url": "https://opencollective.com/synckit"
 			}
+		},
+		"node_modules/text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -6531,6 +6850,19 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 	"dependencies": {
 		"@babel/polyfill": "^7.12.1",
 		"@eslint/eslintrc": "^3.3.5",
-		"@eslint/js": "^9.39.4",
 		"bcryptjs": "^3.0.3",
 		"compression": "^1.7.4",
 		"cookie-parser": "^1.4.6",
@@ -45,8 +44,11 @@
 		"xss-clean": "^0.1.4"
 	},
 	"devDependencies": {
+		"@eslint/compat": "^1.4.1",
+		"@eslint/js": "^8.57.1",
 		"axios": "^1.16.0",
-		"eslint": "^9.39.4",
+		"eslint": "^8.57.1",
+		"eslint-config-airbnb": "^19.0.4",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-import": "^2.32.0",
 		"eslint-plugin-jsx-a11y": "^6.9.0",

--- a/server.js
+++ b/server.js
@@ -11,9 +11,9 @@ dotenv.config({ path: './config.env' });
 
 const app = require('./app');
 
-const DB = process.env.DATABASE.replace(
+const DB = (process.env.DATABASE || process.env.DATABASE_LOCAL).replace(
 	'<PASSWORD>',
-	process.env.DATABASE_PASSWORD,
+	process.env.DATABASE_PASSWORD || '',
 );
 
 mongoose.connect(DB).then(() => console.log('MongoDB Connected...'));

--- a/utils/apiFeatures.js
+++ b/utils/apiFeatures.js
@@ -1,3 +1,5 @@
+const { sanitize } = require('express-mongo-sanitize');
+
 class APIFeatures {
 	constructor(docQuery, reqQuery) {
 		this.docQuery = docQuery;
@@ -5,7 +7,7 @@ class APIFeatures {
 	}
 
 	filter() {
-		const queryObj = { ...this.reqQuery };
+		const queryObj = sanitize({ ...this.reqQuery });
 
 		const excludedFields = ['page', 'sort', 'limit', 'fields'];
 		excludedFields.forEach((el) => delete queryObj[el]);


### PR DESCRIPTION
Fixes Express 5 runtime compatibility issues and gets the repo instructions/tooling in sync with the current stack.

- Uses Express 5-compatible catch-all routes
- Avoids sanitizers mutating read-only `req.query`
- Updates Mongoose middleware hooks for current async style
- Adds repo instructions and fixes ESLint dependency resolution
- Leaves the generated frontend bundle unchanged to avoid committing secret-bearing built output

Tested by running `npx eslint app.js server.js controllers/authController.js models/bookingModel.js models/reviewModel.js models/tourModel.js models/userModel.js` and `npm run build:js`.
