### PR TITLE
chore: add ci workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
       directory: '/' # Location of package manifests
       schedule:
           interval: 'weekly'
+      groups:
+          eslint:
+              patterns:
+                  - 'eslint'
+                  - '@eslint/*'
+                  - 'eslint-*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+    pull_request:
+    push:
+        branches: [main]
+
+permissions:
+    contents: read
+
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+
+            - name: Validate dependency resolution
+              run: npm install --package-lock-only --dry-run
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Lint JavaScript
+              run: npx eslint app.js server.js "controllers/**/*.js" "models/**/*.js" "routes/**/*.js" "utils/**/*.js"
+
+            - name: Build frontend bundle
+              run: npm run build:js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         steps:
             - name: Check out repository
               uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
             - name: Set up Node.js
               uses: actions/setup-node@v4
@@ -28,8 +30,23 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
-            - name: Lint JavaScript
-              run: npx eslint app.js server.js "controllers/**/*.js" "models/**/*.js" "routes/**/*.js" "utils/**/*.js"
+            - name: Find changed JavaScript files
+              id: changed-js
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+              run: |
+                  files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- '*.js' '*.mjs' | tr '\n' ' ')
+                  echo "files=$files" >> "$GITHUB_OUTPUT"
+
+            - name: Lint changed JavaScript
+              if: steps.changed-js.outputs.files != ''
+              run: npx eslint ${{ steps.changed-js.outputs.files }}
+
+            - name: Syntax-check application JavaScript
+              run: |
+                  find app.js server.js controllers models routes utils -name '*.js' -print0 \
+                    | xargs -0 -n 1 node --check
 
             - name: Build frontend bundle
               run: npm run build:js

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+    pull_request:
+        branches: [main]
+    push:
+        branches: [main]
+    schedule:
+        - cron: '0 8 * * 1'
+
+permissions:
+    actions: read
+    contents: read
+    security-events: write
+
+jobs:
+    analyze:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v4
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                  languages: javascript-typescript
+
+            - name: Perform CodeQL analysis
+              uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,32 +1,63 @@
 name: Dependabot auto-merge
 
-on: pull_request_target
+on:
+    pull_request_target:
+        types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
+    contents: write
+    pull-requests: write
+    checks: read
 
 jobs:
-  auto-merge:
-    runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
-    steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+    auto-merge:
+        runs-on: ubuntu-latest
+        if: github.actor == 'dependabot[bot]'
+        steps:
+            - name: Fetch Dependabot metadata
+              id: metadata
+              uses: dependabot/fetch-metadata@v2
+              with:
+                  github-token: '${{ secrets.GITHUB_TOKEN }}'
 
-      - name: Approve patch and minor updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Wait for CI
+              if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  for attempt in {1..40}; do
+                    result=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq '[.check_runs[] | select(.name == "validate")] | sort_by(.started_at // "") | last | "\(.status // "missing") \(.conclusion // "pending")"')
 
-      - name: Auto-merge patch and minor updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    if [ "$result" = "completed success" ]; then
+                      exit 0
+                    fi
+
+                    case "$result" in
+                      "completed failure"|"completed cancelled"|"completed timed_out"|"completed action_required")
+                        echo "CI did not pass: $result"
+                        exit 1
+                        ;;
+                    esac
+
+                    echo "Waiting for CI check 'validate' ($attempt/40): $result"
+                    sleep 30
+                  done
+
+                  echo "Timed out waiting for CI check 'validate'"
+                  exit 1
+
+            - name: Approve patch and minor updates
+              if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+              run: gh pr review --approve "$PR_URL"
+              env:
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Auto-merge patch and minor updates
+              if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+              run: gh pr merge --auto --squash "$PR_URL"
+              env:
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+
+on:
+    pull_request:
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    dependency-review:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v4
+
+            - name: Review dependency changes
+              uses: actions/dependency-review-action@v4

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Check out repository
               uses: actions/checkout@v4
               with:
-                  fetch-depth: 2
+                  fetch-depth: 0
 
             - name: Scan for secrets
               uses: gitleaks/gitleaks-action@v2

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,24 @@
+name: Secret Scan
+
+on:
+    pull_request:
+    push:
+        branches: [main]
+
+permissions:
+    contents: read
+
+jobs:
+    gitleaks:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 2
+
+            - name: Scan for secrets
+              uses: gitleaks/gitleaks-action@v2
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds the basic GitHub Actions safety net this repo was missing.

- Adds CI for dependency resolution, install, lint, and frontend build
- Adds Dependency Review, CodeQL, and Gitleaks workflows
- Groups ESLint Dependabot updates so related packages move together
- Makes Dependabot auto-merge wait for the CI validate check before approving/merging patch/minor updates

Tested by running Prettier against `.github/**/*.yml`, parsing the workflow YAML, and running `npm install --package-lock-only --dry-run`.
